### PR TITLE
Fix for coupon expiration date validation

### DIFF
--- a/src/app/code/community/Hackathon/PromoCodeMessages/Model/Validator.php
+++ b/src/app/code/community/Hackathon/PromoCodeMessages/Model/Validator.php
@@ -163,7 +163,7 @@ class Hackathon_PromoCodeMessages_Model_Validator extends Mage_Core_Model_Abstra
 
         // check to date
         if ($rule->getToDate()) {
-            $toDate = new Zend_Date($rule->getToDate(), Varien_Date::DATE_INTERNAL_FORMAT);
+            $toDate = new Zend_Date($rule->getToDate() . ' 23:59:59', Varien_Date::DATE_INTERNAL_FORMAT);
             if ($now->isLater($toDate)) {
                 Mage::throwException($this->_formatMessage(
                     'Your coupon is no longer valid. It expired on %s.',


### PR DESCRIPTION
It seems when the current date is equal to expiration date there is an incorrect message that coupon is expired because $toDate has the current date with 12 AM for the hour part
